### PR TITLE
Fix an aligned_alloc issue in the test program

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -279,6 +279,8 @@ if (STARNEIG_ENABLE_BLACS AND STARNEIG_ENABLE_REFERENCE)
     endif ()
 endif ()
 
+CHECK_FUNCTION_EXISTS (aligned_alloc ALIGNED_ALLOC_FOUND)
+
 #
 # configuration file
 #

--- a/test/common/common.c
+++ b/test/common/common.c
@@ -102,9 +102,11 @@ void * alloc_matrix(
     if (pinning)
         cudaHostAlloc(&ptr, n*(*ld)*elemsize, cudaHostRegisterPortable);
     else
+#endif
+#ifdef ALIGNED_ALLOC_FOUND
         ptr = aligned_alloc(64, n*(*ld)*elemsize);
 #else
-    ptr = aligned_alloc(64, n*(*ld)*elemsize);
+        ptr = malloc(n*(*ld)*elemsize);
 #endif
     return ptr;
 }

--- a/test/starneig_test_config.h.in
+++ b/test/starneig_test_config.h.in
@@ -40,6 +40,7 @@
 #cmakedefine MKL_SET_NUM_THREADS_LOCAL_FOUND
 #cmakedefine OPENBLAS_SET_NUM_THREADS_FOUND
 #cmakedefine GOTO_SET_NUM_THREADS_FOUND
+#cmakedefine ALIGNED_ALLOC_FOUND
 
 #cmakedefine PDGEHRD_FOUND
 #cmakedefine PDORMHR_FOUND


### PR DESCRIPTION
This PR adds a CMake tests that checks whether `aligned_alloc` exits.